### PR TITLE
nvim: Add Neomake plugin and corresponding autocmd

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -29,6 +29,7 @@ if !empty(glob(g:VIM_CONFIG_HOME . '/autoload/plug.vim'))
 		Plug 'amirh/HTML-AutoCloseTag', { 'for': 'html' } " Auto close html tags
 		Plug 'cespare/vim-toml'                           " Syntax for TOML
 		Plug 'junegunn/vim-easy-align'                    " Easy column-based alignment
+		Plug 'neomake/neomake.git' " Asynchronous :make and lint framework
 		Plug 'rust-lang/rust.vim'                         " Configuration for Rust
 		Plug 'tpope/vim-commentary'                       " Comment and uncomment easily
 		Plug 'tpope/vim-repeat'                           " `.` support for plugins

--- a/nvim/plugin/autocmd.vim
+++ b/nvim/plugin/autocmd.vim
@@ -1,0 +1,4 @@
+augroup AfterWritingBuffer
+	autocmd!
+	autocmd BufWritePost * silent! Neomake
+augroup END


### PR DESCRIPTION
Neomake (https://github.com/neomake/neomake) is an "[a]synchronous
linting and make framework for Neovim/Vim".  We want it to run after
every buffer write.  This is accomplished with an autocmd on
BufWritePost.

The Neomake autocmd is in an augroup to protect it from being sourced
twice.  That augroup in turn is in a file inside the plugin directory;
the contents of plugin are recursively sourced by nvim instances as part
of startup.